### PR TITLE
Denoted by links

### DIFF
--- a/emissor/annotation/backend.py
+++ b/emissor/annotation/backend.py
@@ -139,3 +139,26 @@ class Backend:
 
     def load_instances_of_type(self, class_type: str) -> Iterable[Dict]:
         return self._storage.brain.get_instances_of_type(class_type)
+
+    def create_denotations(self, scenario_id: str, modality: str, signal_id: str, mention_id: str,
+                           annotation_id: str) -> None:
+
+        # Load modality data
+        signals = self.load_modality(scenario_id, Modality[modality.upper()])
+
+        # Filter signals to get the right one
+        signals = [sig for sig in signals if sig.id == signal_id]
+        signal = signals[0]
+
+        # Filter mentions to get the right one
+        mentions = [men for men in signal.mentions if men.id == mention_id]
+        mention = mentions[0]
+
+        # Filter annotations to get the right one
+        annotations = [ann for ann in mention.annotations if ann.value.id == annotation_id]
+        annotation = annotations[0]
+
+        # Create triple
+        triples = self._storage.brain.denote_things(mention, annotation)
+
+        return {"triples": triples}

--- a/emissor/annotation/brain/util.py
+++ b/emissor/annotation/brain/util.py
@@ -2,13 +2,20 @@ from importlib.resources import path
 from pathlib import Path
 from typing import Dict, Iterable
 
-from rdflib import Graph, ConjunctiveGraph
+from rdflib import Graph, ConjunctiveGraph, URIRef, Namespace
 
 
-class Brain:
+class EmissorBrain:
 
     def __init__(self, ememory_path):
+
+        # TODO: Similar to robot platform, a brain needs an RDF Builder (taken from cltl-knowledge representation)
+        # Porting this should give us access to automatic creation of entities, triples, namespaces and named graphs
+        # self._rdf_builder = RdfBuilder()
+
+        # Create graphs: world model, memory and current experiences
         self.ememory_path = Path(ememory_path).resolve()
+        self.interpretations_path = self.ememory_path.parent
 
         with path('emissor.annotation.brain', 'queries') as p:
             self.queries_path = p
@@ -18,6 +25,7 @@ class Brain:
 
         self.ontology = self._load_ontology()
         self.ememory = self._load_memories()
+        self.interpretations_graph = self._create_episode_graph()
 
     def _read_query(self, query_filename: str) -> str:
         file_path = self.queries_path / f"{query_filename}.rq"
@@ -47,6 +55,11 @@ class Brain:
 
         return ememory_graph
 
+    def _create_episode_graph(self) -> ConjunctiveGraph:
+        episode_graph = ConjunctiveGraph()
+
+        return episode_graph
+
     def get_annotation_types(self) -> Iterable[Dict]:
         query = self._read_query('classes_in_brain')
         annotation_types = self._query_graph(self.ontology, query)
@@ -61,3 +74,30 @@ class Brain:
         query = self._read_query('instance_of_type') % instance_type
         annotation_instances = self._query_graph(self.ememory, query)
         return annotation_instances
+
+    def denote_things(self, mention, annotation):
+        # TODO we assume the value of the annotation to be a valid URI,
+        #  but we still have to check this as there is no data to test
+
+        # Create and bind namespaces
+        # TODO this will be much easier once we have the full brain functionality
+        ltalk_ns = Namespace('http://cltl.nl/leolani/talk/')
+        self.interpretations_graph.bind('leolaniTalk', ltalk_ns)
+        gaf_ns = Namespace('http://groundedannotationframework.org/gaf#')
+        self.interpretations_graph.bind('gaf', gaf_ns)
+
+        # Create triple
+        mention_uri = ltalk_ns[mention.id]
+        instance_uri = URIRef(annotation.value.value)
+        self.interpretations_graph.add((instance_uri, gaf_ns['denotedBy'], mention_uri))
+
+        # Save to file but return the string representation
+        with open(f'{self.interpretations_path}/annotation_{annotation.value.id}.trig', 'wb') as f:
+            self.interpretations_graph.serialize(f, format="trig")
+
+        data = self.interpretations_graph.serialize(format="trig")
+
+        # TODO we return the serialized graph with the new triples. TBD if we want to
+        #  a) create a new graph per annotation, VS accumulate on the same graph
+        #  b) return the triples or save them
+        return data.decode("utf-8")

--- a/emissor/annotation/endpoint.py
+++ b/emissor/annotation/endpoint.py
@@ -385,49 +385,44 @@ def create_app(data_path):
         """
         return marshal(backend.load_relation_types())
 
-    @app.route('/api/scenario/<scenario_id>/annotation/<class_type>/instances')
-    def load_annotation_instances(scenario_id: str, class_type: str):
-        """Get all potential annotation instances (according to the given type) based on the episodic memory
-        Lists all instances of the given type in the brain.
+    @app.route('/api/scenario/<scenario_id>/<modality>/<signal_id>/<mention_id>/<annotation_id>/denotedBy')
+    def create_denotedBy(scenario_id: str, modality: str, signal_id: str, mention_id: str, annotation_id: str):
+        """Create links between signal annotations in brain
+        Link mentions to instances by loading the annotations in signals of a given modality in a scenario
         ---
         tags:
-          - annotation-brain
+          - signals
         parameters:
           - name: scenario_id
             in: path
             type: string
             required: true
             default: 'scenario_1'
-          - name: class_type
+          - name: modality
             in: path
             type: string
-            enum: ['n2mu:person', 'n2mu:robot', 'n2mu:object', '<other_class types>']
+            enum: ['image', 'text', 'audio', 'video']
             required: true
-            default: n2mu:person
-        definitions:
-          AnnotationValues:
-            type: array
-            items:
-              $ref: '#/definitions/AnnotationValue'
-          AnnotationValue:
-            type: object
-            properties:
-              full_id:
-                type: URI
-              prefixed_id:
-                type: string
-              prefix:
-                type: string
-              id:
-                type: string
-              label:
-                type: string
+            default: 'text'
+          - name: signal_id
+            in: path
+            type: string
+            required: true
+            default: '4f0bbc71-2369-4d55-8dd0-b00e56c0f0b2'
+          - name: mention_id
+            in: path
+            type: string
+            required: true
+            default: '68fdc43f-cc13-46a9-b9ab-d26abacc8fdb'
+          - name: annotation_id
+            in: path
+            type: string
+            required: true
+            default: '190cb100-e2c7-4f15-9f2f-8c6f3a73a88f'
         responses:
           200:
-            description: A list of instances (filtered by class type) representing potential annotation values
-            schema:
-              $ref: '#/definitions/AnnotationValues'
+            description: Successful addition of the link between mention and an annotation
         """
-        return marshal(backend.load_instances_of_type(class_type))
+        return marshal(backend.create_denotations(scenario_id, modality, signal_id, mention_id, annotation_id))
 
     return app

--- a/emissor/annotation/persistence.py
+++ b/emissor/annotation/persistence.py
@@ -6,7 +6,7 @@ import pandas as pd
 from PIL import Image
 from pandas import DataFrame
 
-from emissor.annotation.brain.util import Brain
+from emissor.annotation.brain.util import EmissorBrain
 from emissor.annotation.cache import ScenarioCache
 from emissor.representation.scenario import Scenario, Modality, Signal
 from emissor.representation.util import unmarshal, marshal
@@ -130,8 +130,9 @@ class ScenarioStorage:
 
         self._cache = ScenarioCache(scenario_id)
 
+        # Load memories
         ememory_path = self._get_path(scenario_id, 'rdf', 'episodic_memory', extension=None)
-        self.brain = Brain(ememory_path)
+        self.brain = EmissorBrain(ememory_path)
 
         return scenario
 

--- a/example_data/CarLani/train/carl-leolani/rdf/episodic_memory/.gitignore
+++ b/example_data/CarLani/train/carl-leolani/rdf/episodic_memory/.gitignore
@@ -1,0 +1,2 @@
+!.gitignore
+*.trig

--- a/example_data/scenario_1/rdf/annotation_190cb100-e2c7-4f15-9f2f-8c6f3a73a88f.trig
+++ b/example_data/scenario_1/rdf/annotation_190cb100-e2c7-4f15-9f2f-8c6f3a73a88f.trig
@@ -1,0 +1,7 @@
+@prefix gaf: <http://groundedannotationframework.org/gaf#> .
+@prefix leolaniTalk: <http://cltl.nl/leolani/talk/> .
+
+{
+    <This> gaf:denotedBy leolaniTalk:68fdc43f-cc13-46a9-b9ab-d26abacc8fdb .
+}
+

--- a/example_data/scenario_1/rdf/episodic_memory/.gitignore
+++ b/example_data/scenario_1/rdf/episodic_memory/.gitignore
@@ -1,0 +1,2 @@
+!.gitignore
+*.trig

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Flask==1.1.2
 Flask-Cors==3.0.9
 nltk==3.5
+marshmallow==3.11.1
 marshmallow-dataclass==8.4.1
 numpy==1.20.0
 numpy==1.20.0

--- a/tests/test_emissor/test_representation/test_util.py
+++ b/tests/test_emissor/test_representation/test_util.py
@@ -1,21 +1,23 @@
+import uuid
 from dataclasses import dataclass
 from typing import Union, Optional
 from unittest import TestCase
+from uuid import UUID
 
 from emissor.representation.util import marshal, unmarshal
 
 
-class TestMarshalling(TestCase):
+class TestMarshallingWithTypes(TestCase):
     def test_plain(self):
         @dataclass
         class TestString:
             label: str
 
         instance = TestString("testString")
-        unmarshalled = unmarshal(marshal(instance), TestString)
+        unmarshalled = unmarshal(marshal(instance, cls=TestString), cls=TestString)
 
         self.assertIsInstance(unmarshalled, TestString)
-        self.assertEquals(unmarshalled.label, "testString")
+        self.assertEqual(unmarshalled.label, "testString")
 
     def test_with_nested(self):
         @dataclass
@@ -27,11 +29,11 @@ class TestMarshalling(TestCase):
             nested: TestString
 
         instance = NestTest(TestString("testString"))
-        unmarshalled = unmarshal(marshal(instance), NestTest)
+        unmarshalled = unmarshal(marshal(instance, cls=NestTest), cls=NestTest)
 
         self.assertIsInstance(unmarshalled, NestTest)
         self.assertIsInstance(unmarshalled.nested, TestString)
-        self.assertEquals(unmarshalled.nested.label, "testString")
+        self.assertEqual(unmarshalled.nested.label, "testString")
 
     def test_with_nested_union(self):
         @dataclass
@@ -47,18 +49,18 @@ class TestMarshalling(TestCase):
             nested: Union[TestString, TestInt]
 
         instance = NestTest(TestString("testString"))
-        unmarshalled = unmarshal(marshal(instance), NestTest)
+        unmarshalled = unmarshal(marshal(instance, cls=NestTest), cls=NestTest)
 
         self.assertIsInstance(unmarshalled, NestTest)
         self.assertIsInstance(unmarshalled.nested, TestString)
-        self.assertEquals(unmarshalled.nested.label, "testString")
+        self.assertEqual(unmarshalled.nested.label, "testString")
 
         instance = NestTest(TestInt(5))
-        unmarshalled = unmarshal(marshal(instance), NestTest)
+        unmarshalled = unmarshal(marshal(instance, cls=NestTest), cls=NestTest)
 
         self.assertIsInstance(unmarshalled, NestTest)
         self.assertIsInstance(unmarshalled.nested, TestInt)
-        self.assertEquals(unmarshalled.nested.id, 5)
+        self.assertEqual(unmarshalled.nested.id, 5)
 
     def test_with_none_value(self):
         @dataclass
@@ -66,36 +68,253 @@ class TestMarshalling(TestCase):
             label: Optional[str]
 
         instance = TestString(None)
-        unmarshalled = unmarshal(marshal(instance), TestString)
+        unmarshalled = unmarshal(marshal(instance, cls=TestString), cls=TestString)
 
         self.assertIsInstance(unmarshalled, TestString)
-        self.assertEquals(unmarshalled.label, None)
+        self.assertEqual(unmarshalled.label, None)
 
     def test_json_with_missing_property(self):
         @dataclass
         class TestString:
             label: Optional[str]
 
-        unmarshalled = unmarshal("{}", TestString)
+        unmarshalled = unmarshal("{}", cls=TestString)
 
         self.assertIsInstance(unmarshalled, TestString)
-        self.assertEquals(unmarshalled.label, None)
+        self.assertEqual(unmarshalled.label, None)
 
-    def test_json_to_namedtuple(self):
+    def test_list(self):
+        @dataclass(frozen=True)
+        class TestString:
+            label: str
+
+        instance = [TestString("test1"), TestString("test2")]
+        unmarshalled = unmarshal(marshal(instance, cls=TestString), cls=TestString)
+
+        self.assertIsInstance(unmarshalled, list)
+        self.assertListEqual(unmarshalled, instance)
+
+    def test_set(self):
+        @dataclass(frozen=True)
+        class TestString:
+            label: str
+
+        instance = {TestString("test1"), TestString("test2")}
+        unmarshalled = unmarshal(marshal(instance, cls=TestString), cls=TestString)
+
+        self.assertIsInstance(unmarshalled, list)
+        self.assertSetEqual(set(unmarshalled), instance)
+
+    def test_type_unsupported_by_serializer(self):
+        @dataclass
+        class TestString:
+            label: uuid.UUID
+
+        instance = TestString(uuid.uuid4())
+        self.assertRaises(TypeError, lambda: marshal(instance, default=vars))
+
+        unmarshalled = unmarshal(marshal(instance, cls=TestString), cls=TestString)
+        self.assertIsInstance(unmarshalled, TestString)
+        self.assertIsInstance(unmarshalled.label, uuid.UUID)
+
+
+class TestMarshallingWithoutTypes(TestCase):
+    def test_plain(self):
+        @dataclass
+        class TestString:
+            label: str
+
+        instance = TestString("testString")
+        unmarshalled = unmarshal(marshal(instance))
+
+        self.assertNotIsInstance(unmarshalled, TestString)
+        self.assertEqual(unmarshalled.label, "testString")
+
+    def test_with_nested(self):
+        @dataclass
+        class TestString:
+            label: str
+
+        @dataclass
+        class NestTest:
+            nested: TestString
+
+        instance = NestTest(TestString("testString"))
+        unmarshalled = unmarshal(marshal(instance))
+
+        self.assertNotIsInstance(unmarshalled, NestTest)
+        self.assertNotIsInstance(unmarshalled.nested, TestString)
+        self.assertEqual(unmarshalled.nested.label, "testString")
+
+    def test_with_nested_union(self):
+        @dataclass
+        class TestString:
+            label: str
+
+        @dataclass
+        class TestInt:
+            id: int
+
+        @dataclass
+        class NestTest:
+            nested: Union[TestString, TestInt]
+
+        instance = NestTest(TestString("testString"))
+        unmarshalled = unmarshal(marshal(instance))
+
+        self.assertNotIsInstance(unmarshalled, NestTest)
+        self.assertNotIsInstance(unmarshalled.nested, TestString)
+        self.assertEqual(unmarshalled.nested.label, "testString")
+
+        instance = NestTest(TestInt(5))
+        unmarshalled = unmarshal(marshal(instance))
+
+        self.assertNotIsInstance(unmarshalled, NestTest)
+        self.assertNotIsInstance(unmarshalled.nested, TestInt)
+        self.assertEqual(unmarshalled.nested.id, 5)
+
+    def test_with_none_value(self):
         @dataclass
         class TestString:
             label: Optional[str]
 
-        unmarshalled = unmarshal('{"label": "testString"}')
+        instance = TestString(None)
+        unmarshalled = unmarshal(marshal(instance))
 
         self.assertNotIsInstance(unmarshalled, TestString)
-        self.assertEquals(unmarshalled.label, "testString")
+        self.assertEqual(unmarshalled.label, None)
 
-    def test_json_with_missing_property_to_namedtuple(self):
+    def test_json_with_missing_property(self):
         @dataclass
         class TestString:
             label: Optional[str]
 
         unmarshalled = unmarshal("{}")
 
+        self.assertNotIsInstance(unmarshalled, TestString)
         self.assertRaises(AttributeError, lambda: unmarshalled.label)
+
+    def test_list(self):
+        @dataclass(frozen=True)
+        class TestString:
+            label: str
+
+        instance = [TestString("test1"), TestString("test2")]
+        json = marshal(instance)
+        unmarshalled = unmarshal(json)
+
+        self.assertIsInstance(unmarshalled, list)
+        self.assertListEqual([u.label for u in unmarshalled], [i.label for i in instance])
+
+    def test_set(self):
+        @dataclass(frozen=True)
+        class TestString:
+            label: str
+
+        instance = {TestString("test1"), TestString("test2")}
+        json = marshal(instance)
+        unmarshalled = unmarshal(json)
+
+        self.assertIsInstance(unmarshalled, list)
+        self.assertSetEqual({u.label for u in unmarshalled}, {i.label for i in instance})
+
+
+class TestOnlyUnmarshallingWithTypes(TestCase):
+    def test_plain(self):
+        @dataclass
+        class TestString:
+            label: str
+
+        instance = TestString("testString")
+        unmarshalled = unmarshal(marshal(instance), cls=TestString)
+
+        self.assertIsInstance(unmarshalled, TestString)
+        self.assertEqual(unmarshalled.label, "testString")
+
+    def test_with_nested(self):
+        @dataclass
+        class TestString:
+            label: str
+
+        @dataclass
+        class NestTest:
+            nested: TestString
+
+        instance = NestTest(TestString("testString"))
+        unmarshalled = unmarshal(marshal(instance), cls=NestTest)
+
+        self.assertIsInstance(unmarshalled, NestTest)
+        self.assertIsInstance(unmarshalled.nested, TestString)
+        self.assertEqual(unmarshalled.nested.label, "testString")
+
+    def test_with_nested_union(self):
+        @dataclass
+        class TestString:
+            label: str
+
+        @dataclass
+        class TestInt:
+            id: int
+
+        @dataclass
+        class NestTest:
+            nested: Union[TestString, TestInt]
+
+        instance = NestTest(TestString("testString"))
+        unmarshalled = unmarshal(marshal(instance), cls=NestTest)
+
+        self.assertIsInstance(unmarshalled, NestTest)
+        self.assertIsInstance(unmarshalled.nested, TestString)
+        self.assertEqual(unmarshalled.nested.label, "testString")
+
+        instance = NestTest(TestInt(5))
+        unmarshalled = unmarshal(marshal(instance), cls=NestTest)
+
+        self.assertIsInstance(unmarshalled, NestTest)
+        self.assertIsInstance(unmarshalled.nested, TestInt)
+        self.assertEqual(unmarshalled.nested.id, 5)
+
+    def test_with_none_value(self):
+        @dataclass
+        class TestString:
+            label: Optional[str]
+
+        instance = TestString(None)
+        unmarshalled = unmarshal(marshal(instance), cls=TestString)
+
+        self.assertIsInstance(unmarshalled, TestString)
+        self.assertEqual(unmarshalled.label, None)
+
+    def test_json_with_missing_property(self):
+        @dataclass
+        class TestString:
+            label: Optional[str]
+
+        unmarshalled = unmarshal("{}", cls=TestString)
+
+        self.assertIsInstance(unmarshalled, TestString)
+        self.assertEqual(unmarshalled.label, None)
+
+    def test_list(self):
+        @dataclass(frozen=True)
+        class TestString:
+            label: str
+
+        instance = [TestString("test1"), TestString("test2")]
+        json = marshal(instance)
+        unmarshalled = unmarshal(json, cls=TestString)
+
+        self.assertIsInstance(unmarshalled, list)
+        self.assertListEqual(unmarshalled, instance)
+
+    def test_set(self):
+        @dataclass(frozen=True)
+        class TestString:
+            label: str
+
+        instance = {TestString("test1"), TestString("test2")}
+        json = marshal(instance)
+        unmarshalled = unmarshal(json, cls=TestString)
+
+        self.assertIsInstance(unmarshalled, list)
+        self.assertSetEqual(set(unmarshalled), instance)


### PR DESCRIPTION
This PR implements the creation of "gaf:denotedBy" links between mentions and instances. In the current EMISSOR model, an annotation of type 'entity linking' within a mention will have the instance information. We assume the value of the annotation to be a valid URI. 


TO DO:
- [ ] Test functionality once the entity linking annotations are there
- [ ] Decide whether the interpretations are accumulated into a single graph, or separated
- [ ] Decide if we return the triples or save them to file (related to above)



PS. This is a temporary fix, for full brain functionality we need to import [some classes](https://github.com/leolani/cltl-knowledgerepresentation/tree/main/leolani/brain/infrastructure) from the [cltl-knowledgerepresentation](https://github.com/leolani/cltl-knowledgerepresentation)(aka brain) module